### PR TITLE
RPM Packaging .spec File

### DIFF
--- a/etc/rpm/perl-Process-SubProcess.spec
+++ b/etc/rpm/perl-Process-SubProcess.spec
@@ -1,0 +1,57 @@
+#
+# spec file for package perl-Process-SubProcess
+#
+
+
+Name: perl-Process-SubProcess
+Version: 1.0
+Release: 20200915gitf253067
+Summary: Perl Library for Multiprocessing
+License: see https://dev.perl.org/licenses/
+Group: 		Development/Libraries
+Source:         Process-SubProcess.tar.gz
+
+BuildArch:      noarch
+
+Requires:       perl(Test::More)
+Requires:       perl(Data::Dump)
+Requires:	perl(Time::HiRes)
+Requires:	perl(IPC::Open3)
+
+
+
+%description
+Running Sub Processes in an easy way while reading STDOUT, STDERR, Exit Code and possible System Errors.
+It also implements running multiple Sub Processes simultaneously while keeping all Report and Error Messages and Exit Codes seperate.
+
+
+%prep
+%setup -q -n Process-SubProcess
+
+
+%build
+
+
+%install
+rm -rf %{buildroot}
+
+mkdir -p %{buildroot}%{perl_vendorlib}
+mkdir -p %{buildroot}%{_docdir}/%{name}
+
+mv README.md %{buildroot}%{_docdir}/%{name}/
+mv t %{buildroot}%{_docdir}/%{name}/tests
+
+find ./ -type f -name '.gitignore' -exec rm -f {} \;
+
+mv lib/Process %{buildroot}%{perl_vendorlib}/
+
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+
+%files
+%doc %{_docdir}/%{name}/README.md
+%{perl_vendorlib}/Process
+%dir %{_docdir}/%{name}
+%{_docdir}/%{name}/tests

--- a/etc/rpm/perl-Process-SubProcess.spec
+++ b/etc/rpm/perl-Process-SubProcess.spec
@@ -5,7 +5,7 @@
 
 Name: perl-Process-SubProcess
 Version: 1.0
-Release: 20200915gitf253067
+Release: 20200920git4673b4e
 Summary: Perl Library for Multiprocessing
 License: see https://dev.perl.org/licenses/
 Group: 		Development/Libraries
@@ -14,9 +14,6 @@ Source:         Process-SubProcess.tar.gz
 BuildArch:      noarch
 
 Requires:       perl(Test::More)
-Requires:       perl(Data::Dump)
-Requires:	perl(Time::HiRes)
-Requires:	perl(IPC::Open3)
 
 
 
@@ -35,6 +32,9 @@ It also implements running multiple Sub Processes simultaneously while keeping a
 %install
 rm -rf %{buildroot}
 
+
+rm -rf %{buildroot}
+
 mkdir -p %{buildroot}%{perl_vendorlib}
 mkdir -p %{buildroot}%{_docdir}/%{name}
 
@@ -42,8 +42,6 @@ mv README.md %{buildroot}%{_docdir}/%{name}/
 mv t %{buildroot}%{_docdir}/%{name}/tests
 
 find ./ -type f -name '.gitignore' -exec rm -f {} \;
-
-rm -fR etc
 
 mv lib/Process %{buildroot}%{perl_vendorlib}/
 

--- a/etc/rpm/perl-Process-SubProcess.spec
+++ b/etc/rpm/perl-Process-SubProcess.spec
@@ -43,6 +43,8 @@ mv t %{buildroot}%{_docdir}/%{name}/tests
 
 find ./ -type f -name '.gitignore' -exec rm -f {} \;
 
+rm -fR etc
+
 mv lib/Process %{buildroot}%{perl_vendorlib}/
 
 


### PR DESCRIPTION
This provides the `.spec` File to create an installable RPM Package File `.rpm`.

On successful installation the tests at `/usr/share/doc/perl-Process-SubProcess/tests/` should work.

**Requirements for the Build:**
- Project Source Code resides in the `Process-SubProcess` Directory
- Project Source Code is packaged as `Process-SubProcess.tar.gz`

**Issues noticed during Packaging:**
- Missing Project Summary
- Missing Pod Documentation
- Missing License Notice
