### PR TITLE
Suppressing System Error 29 on open3() Call

### DIFF
--- a/lib/Process/SubProcess.pm
+++ b/lib/Process/SubProcess.pm
@@ -494,6 +494,16 @@ sub Launch
       $self->{'_error_code'} = 1 if($self->{'_error_code'} < 1);
     } #if($@)
 
+    if(defined $self->{'_pid'}
+      && $self->{'_pid'} > 0)
+    {
+      #The open3() Call has succeeded
+
+      #Suppressing the System Error 29 silently
+      $! = 0 if(($! + 0) == 29);
+
+    } #if(defined $self->{'_pid'} && $self->{'_pid'} > 0)
+
     if($!)
     {
       $self->{'_pid'} = -1;


### PR DESCRIPTION
This System Error occurs especially on "_Centos6_" Systems but is fatal for the Application
```
$ cat /etc/centos-release
CentOS release 6.10 (Final)
```

Introducing Checks into the `quiet_script.pl` Test it shows that there isn't any **System Error** before the `open3()` Call and right after it it was generated.
Still this error is not fatal for the Sub Process Launch.
Also the usage of `$!` is not documented in the Official Documentation at:
[IPC::Open3 Documentation](https://metacpan.org/pod/IPC::Open3#DESCRIPTION)
So finding a Sub Process PID set I understand the Sub Process Launch as succeeded.
So I suggest to suppress this System Error to not obstaclize the Processing.

With this change both test scripts `quiet_script.pl` and `test_script.pl` run correctly now:
```
$ perl -MProcess::SubProcess -e 'print "starting ...\n"; my ($out, $err, $ext) = Process::SubProcess::runSubProcess(("command" => "./quiet_script.pl", "debug" => 1, "check" => 2)); print "done.\n"; print "STDOUT:\n$$out\nSTDERR:\n$$err\nEXIT: $ext\n"; '
starting ...
done.
STDOUT:
Process::SubProcess::Run - go ...
Process::SubProcess::Launch - go ...
Sub Process './quiet_script.pl': Launching ...
cmd: './quiet_script.pl'
cmd pfg '0'
sys err 0 [0]: ''
sys err 1 [0]: ''
cmd pid 2: '19654'
sys err 2 [29]: 'Illegal seek'
Sub Process './quiet_script.pl': Launch OK - PID (19654)
Process::SubProcess::Wait - go ...
'Process::SubProcess::Wait' : Signal to 'Process::SubProcess::Check'
Process::SubProcess::Check - go ...
Process::SubProcess::Check - wait on (19654) - fnsh pid: (0); stt cd: [-1]
prc (19654): Read checking ...
Process::SubProcess::Read - go ...
prc (19654) [-1]: try read ...
prc (19654): try read '2' pipes
pipe (5): transmission done.
pipe (7): transmission done.
prc (19654): try read done. '0' pipes left.
'Process::SubProcess::Wait' : Signal to 'Process::SubProcess::Check'
Process::SubProcess::Check - go ...
Process::SubProcess::Check - wait on (19654) - fnsh pid: (19654); stt cd: [0]
prc (19654): done.
cmd fnshd [0].
cmd stt cd: '0 / 0 >> 0'
Process::SubProcess::Read - go ...
prc (19654) [0]: try read ...
prc (19654): try read '0' pipes
prc (19654): try read done. '0' pipes left.
'Process::SubProcess::runSubProcess' : Signal to 'Process::SubProcess::freeResources'

STDERR:

EXIT: 0
```
and the test script `test_script.pl`:
```
$ perl -MProcess::SubProcess -e 'print "starting ...\n"; my ($out, $err, $ext) = Process::SubProcess::runSubProcess(("command" => "./test_script.pl", "debug" => 1, "check" => 2)); print "done.\n"; print "STDOUT:\n$$out\nSTDERR:\n$$err\nEXIT: $ext\n"; '
starting ...
done.
STDOUT:
Process::SubProcess::Run - go ...
Process::SubProcess::Launch - go ...
Sub Process './test_script.pl': Launching ...
cmd: './test_script.pl'
cmd pfg '0'
sys err 0 [0]: ''
sys err 1 [0]: ''
cmd pid 2: '19924'
sys err 2 [29]: 'Illegal seek'
Sub Process './test_script.pl': Launch OK - PID (19924)
Process::SubProcess::Wait - go ...
'Process::SubProcess::Wait' : Signal to 'Process::SubProcess::Check'
Process::SubProcess::Check - go ...
Process::SubProcess::Check - wait on (19924) - fnsh pid: (0); stt cd: [-1]
prc (19924): Read checking ...
Process::SubProcess::Read - go ...
prc (19924) [-1]: try read ...
prc (19924): try read '2' pipes
pipe (7): reading error ...
pipe (5): reading report ...
Start - Time Now: '1601549126.02019' s
script 'test_script.pl' START 0
script 'test_script.pl' PAUSE '0' ...
script 'test_script.pl' END 1
End - Time Now: '1601549126.02028' s
script 'test_script.pl' done in '0.0898838043212891' ms
script 'test_script.pl' EXIT '0'
pipe (5): transmission done.
pipe (7): transmission done.
prc (19924): try read done. '0' pipes left.
'Process::SubProcess::Wait' : Signal to 'Process::SubProcess::Check'
Process::SubProcess::Check - go ...
Process::SubProcess::Check - wait on (19924) - fnsh pid: (19924); stt cd: [0]
prc (19924): done.
cmd fnshd [0].
cmd stt cd: '0 / 0 >> 0'
Process::SubProcess::Read - go ...
prc (19924) [0]: try read ...
prc (19924): try read '0' pipes
prc (19924): try read done. '0' pipes left.
'Process::SubProcess::runSubProcess' : Signal to 'Process::SubProcess::freeResources'

STDERR:
script 'test_script.pl' START 0 ERROR
script 'test_script.pl' END 1 ERROR

EXIT: 0
```