### PR TITLE
fix perl version requirement

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,7 @@ use ExtUtils::MakeMaker;
 WriteMakefile(
     NAME             => 'Process::SubProcess',
     VERSION_FROM     => 'lib/Process/SubProcess.pm',
-    MIN_PERL_VERSION => '5.10',
+    MIN_PERL_VERSION => '5.010',
     test             => {TESTS => 't/*.t'}
 );
 


### PR DESCRIPTION
The currenly latest perl 5.36 is expressed in this format as 5.036, so 5.10 meant the library requires a version of due in some 35 years.