### PR TITLE
include link to the github repo of the project

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,6 +6,19 @@ WriteMakefile(
     NAME             => 'Process::SubProcess',
     VERSION_FROM     => 'lib/Process/SubProcess.pm',
     MIN_PERL_VERSION => '5.10',
-    test             => {TESTS => 't/*.t'}
+    test             => {TESTS => 't/*.t'},
+    META_MERGE => {
+        'meta-spec' => { version => 2 },
+         resources => {
+             repository => {
+                 type => 'git',
+                 url  => 'https://github.com/bodo-hugo-barwich/Process.git',
+                 web  => 'https://github.com/bodo-hugo-barwich/Process',
+             },
+             bugtracker => {
+                 web => 'https://github.com/bodo-hugo-barwich/Process/issues'
+             },
+         },
+    },
 );
 


### PR DESCRIPTION
This will add it to the META.json and META.yml files when they are generated at the time of release. That will allow [MetaCPAN](https://metacpan.org/dist/Process-SubProcess) to link to this repository making it easier for potential contributors to find it.