### PR TITLE
Fix Runners Test

### DIFF
--- a/lib/Process/SubProcess.pm
+++ b/lib/Process/SubProcess.pm
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # @author Bodo (Hugo) Barwich
-# @version 2023-08-05
+# @version 2023-08-06
 # @package SubProcess Management
 # @subpackage Process/SubProcess.pm
 
@@ -45,7 +45,7 @@ use IO::Select;
 use IPC::Open3;
 use Symbol qw(gensym);
 
-our $VERSION = '2.1.2';
+our $VERSION = '2.1.3';
 
 =head1 DESCRIPTION
 

--- a/t/test_runner.t
+++ b/t/test_runner.t
@@ -150,7 +150,7 @@ subtest 'Runner JSON Result' => sub {
   ok($irunnerstatus =~ qr/^-?\d$/, "Runner EXIT CODE is numeric");
   is($irunnerstatus, 0, "Runner EXIT CODE '0' is correct");
 
-  $runnerresult = undef
+  $runnerresult = undef;
   $sscriptsummary = undef;
   $sscriptlog = undef;
   $scripterror = undef;
@@ -218,7 +218,7 @@ subtest 'Runner YAML Result' => sub {
   ok($irunnerstatus =~ qr/^-?\d$/, "Runner EXIT CODE is numeric");
   is($irunnerstatus, 0, "Runner EXIT CODE '0' is correct");
 
-  $runnerresult = undef
+  $runnerresult = undef;
   $sscriptsummary = undef;
   $sscriptlog = undef;
   $scripterror = undef;


### PR DESCRIPTION
Fix missing semicolon in `t/test_runner.t` reportes by CPAN-Testers on:
[Error Report from CPAN-Testers ](https://github.com/bodo-hugo-barwich/Process/issues/39) 