### PR TITLE
Runner Test fails on certain Scenarios

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,4 @@
-use ExtUtils::MakeMaker::CPANfile;
+use ExtUtils::MakeMaker;
  
 
 
@@ -11,6 +11,13 @@ WriteMakefile(
 #    VERSION     => '2.0.2',
     MIN_PERL_VERSION => '5.010',
     test             => {TESTS => 't/*.t'},
+	  PREREQ_PM => {
+	    'Getopt::Long::Descriptive' => '0',
+	    'Path::Tiny' => '0',
+	    'JSON' => '0',
+	    'YAML' => '0',
+	    'Data::Dump' => '0',
+	  },
     META_MERGE => {
         'meta-spec' => { version => 2 },
          resources => {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![Automated Tests](https://github.com/bodo-hugo-barwich/Process/workflows/Automated%20Tests/badge.svg)
-[![Build Status](https://travis-ci.com/bodo-hugo-barwich/Process.svg?branch=master)](https://travis-ci.com/bodo-hugo-barwich/Process)
+[![Automated Tests](https://github.com/bodo-hugo-barwich/Process/actions/workflows/automated_testing.yml/badge.svg)](https://github.com/bodo-hugo-barwich/Process/actions/workflows/automated_testing.yml)
+[![Publish new Release](https://github.com/bodo-hugo-barwich/Process/actions/workflows/publish_release.yml/badge.svg)](https://github.com/bodo-hugo-barwich/Process/actions/workflows/publish_release.yml)
 
 # Process
 Process::SubProcess - Perl Module for Multiprocessing

--- a/bin/run_subprocess.pl
+++ b/bin/run_subprocess.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!perl
 
 # @author Bodo (Hugo) Barwich
 # @version 2023-07-06

--- a/bin/run_subprocess.pl
+++ b/bin/run_subprocess.pl
@@ -1,4 +1,4 @@
-#!perl
+#!/usr/bin/perl
 
 # @author Bodo (Hugo) Barwich
 # @version 2023-07-06

--- a/bin/run_subprocess.pl
+++ b/bin/run_subprocess.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # @author Bodo (Hugo) Barwich
-# @version 2023-07-06
+# @version 2023-08-20
 # @package Process::SubProcess
 # @subpackage bin/run_subprocess.pl
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,3 @@
-requires 'ExtUtils::MakeMaker';
 requires 'Getopt::Long::Descriptive';
 requires 'Path::Tiny';
 requires 'JSON';

--- a/lib/Process/SubProcess.pm
+++ b/lib/Process/SubProcess.pm
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # @author Bodo (Hugo) Barwich
-# @version 2023-08-06
+# @version 2023-08-07
 # @package SubProcess Management
 # @subpackage Process/SubProcess.pm
 
@@ -45,7 +45,7 @@ use IO::Select;
 use IPC::Open3;
 use Symbol qw(gensym);
 
-our $VERSION = '2.1.3';
+our $VERSION = '2.1.4';
 
 =head1 DESCRIPTION
 

--- a/lib/Process/SubProcess.pm
+++ b/lib/Process/SubProcess.pm
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # @author Bodo (Hugo) Barwich
-# @version 2023-08-07
+# @version 2023-08-20
 # @package SubProcess Management
 # @subpackage Process/SubProcess.pm
 

--- a/t/test_runner.t
+++ b/t/test_runner.t
@@ -163,7 +163,7 @@ subtest 'Runner JSON Result' => sub {
   };
 
   if ($@) {
-  	fails("Runner Result is not valid JSON: $@");
+  	fail("Runner Result is not valid JSON: $@");
   }
 
   isnt($runnerresult, undef, "Runner Result is valid JSON");
@@ -231,7 +231,7 @@ subtest 'Runner YAML Result' => sub {
   };
 
   if ($@) {
-    fails("Runner Result is not valid YAML: $@");
+    fail("Runner Result is not valid YAML: $@");
   }
 
   isnt($runnerresult, undef, "Runner Result is valid YAML");

--- a/t/test_runner.t
+++ b/t/test_runner.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # @author Bodo (Hugo) Barwich
-# @version 2023-07-06
+# @version 2023-08-20
 # @package Test for the 'run_subprocess.pl' Runner Script
 # @subpackage t/test_runner.t
 
@@ -64,6 +64,7 @@ my $iprccnt = -1;
 my $iprctmoutcnt = -1;
 
 
+print "Perl Interpreter Path: '", $Config{perlpath}, "'\n";
 
 subtest 'Runner Script Usage' => sub {
 

--- a/t/test_runner.t
+++ b/t/test_runner.t
@@ -17,6 +17,7 @@
 use warnings;
 use strict;
 
+use Config;
 use Cwd qw(abs_path);
 
 use JSON qw(decode_json);
@@ -66,7 +67,7 @@ my $iprctmoutcnt = -1;
 
 subtest 'Runner Script Usage' => sub {
 
-  $srunnerresult = `${spath}${srunnerscript} -n "runner usage" -h`;
+  $srunnerresult = `$Config{perlpath} ${spath}${srunnerscript} -n "runner usage" -h`;
   $irunnerstatus = $?;
 
   isnt($srunnerresult, undef, "Runner Result is returned");
@@ -81,7 +82,7 @@ subtest 'Runner Plain Text Result' => sub {
   $itestpause = 1;
   $iteststatus = 4;
 
-  $srunnerresult = `${spath}${srunnerscript} -n "script exit code '4' - plain" -c "${spath}${stestscript} $itestpause $iteststatus"`;
+  $srunnerresult = `$Config{perlpath} ${spath}${srunnerscript} -n "script exit code '4' - plain" -c "${spath}${stestscript} $itestpause $iteststatus"`;
   $irunnerstatus = $?;
 
   print("Runner Result:\n'$srunnerresult'\n");
@@ -140,7 +141,7 @@ subtest 'Runner JSON Result' => sub {
   $itestpause = 1;
   $iteststatus = 4;
 
-  $srunnerresult = `${spath}${srunnerscript} -n "script exit code '4' - json" -c "${spath}${stestscript} $itestpause $iteststatus" -f json`;
+  $srunnerresult = `$Config{perlpath} ${spath}${srunnerscript} -n "script exit code '4' - json" -c "${spath}${stestscript} $itestpause $iteststatus" -f json`;
   $irunnerstatus = $?;
 
   print("Runner Result:\n'$srunnerresult'\n");
@@ -208,7 +209,7 @@ subtest 'Runner YAML Result' => sub {
   $itestpause = 1;
   $iteststatus = 4;
 
-  $srunnerresult = `${spath}${srunnerscript} -n "script exit code '4' - yaml" -c "${spath}${stestscript} $itestpause $iteststatus" -f yaml`;
+  $srunnerresult = `$Config{perlpath} ${spath}${srunnerscript} -n "script exit code '4' - yaml" -c "${spath}${stestscript} $itestpause $iteststatus" -f yaml`;
   $irunnerstatus = $?;
 
   print("Runner Result:\n'$srunnerresult'\n");
@@ -277,7 +278,7 @@ subtest 'Runner Plain Text Boundary' => sub {
 
   $itestpause = 1;
 
-  $srunnerresult = `${spath}${srunnerscript} -n "script - plain boundary" -c "${spath}${stestscript} $itestpause" -b "$soutputboundary"`;
+  $srunnerresult = `$Config{perlpath} ${spath}${srunnerscript} -n "script - plain boundary" -c "${spath}${stestscript} $itestpause" -b "$soutputboundary"`;
   $irunnerstatus = $?;
 
   print("Runner Result:\n'$srunnerresult'\n");
@@ -335,7 +336,7 @@ subtest 'Runner Timeout Error' => sub {
 
   $itestpause = 3;
 
-  $srunnerresult = `${spath}${srunnerscript} -n "script - times out" -c "${spath}${stestscript} $itestpause" -t 2`;
+  $srunnerresult = `$Config{perlpath} ${spath}${srunnerscript} -n "script - times out" -c "${spath}${stestscript} $itestpause" -t 2`;
   $irunnerstatus = $?;
 
   print("Runner Result:\n'$srunnerresult'\n");
@@ -395,7 +396,7 @@ subtest 'Runner Exit Code' => sub {
 	  $itestpause = 1;
 	  $iteststatus = 6;
 
-	  $srunnerresult = `${spath}${srunnerscript} -n "script - exit code" -c "${spath}${stestscript} $itestpause $iteststatus" -x`;
+	  $srunnerresult = `$Config{perlpath} ${spath}${srunnerscript} -n "script - exit code" -c "${spath}${stestscript} $itestpause $iteststatus" -x`;
 	  $irunnerstatus = ( $? >> 8 );
 
 	  print("Runner Result:\n'$srunnerresult'\n");
@@ -451,7 +452,7 @@ subtest 'Runner Exit Code' => sub {
   subtest 'Runner returns Error Code' => sub {
     $itestpause = 4;
 
-    $srunnerresult = `${spath}${srunnerscript} -n "script - times out" -c "${spath}${stestscript} $itestpause" -t 1 -x`;
+    $srunnerresult = `$Config{perlpath} ${spath}${srunnerscript} -n "script - times out" -c "${spath}${stestscript} $itestpause" -t 1 -x`;
     $irunnerstatus = ( $? >> 8 );
 
     print("Runner Result:\n'$srunnerresult'\n");


### PR DESCRIPTION
fail() function on exception

CPAN-Testers report at:
[Process-SubProcess-2.1.3 5.36.0 FreeBSD](http://www.cpantesters.org/cpan/report/34c7af52-3497-11ee-bed3-d02d6e8775ea)
```
Undefined subroutine &main::fails called at t/test_runner.t line 166.
# Tests were run but no plan was declared and done_testing() was not seen.
```

This relates to the issues:
* [Distribution incomplete](https://github.com/bodo-hugo-barwich/Process/issues/37)
* [CPAN-Testers Scenarios failing](https://github.com/bodo-hugo-barwich/Process/issues/39)