### PR TITLE
Extend Process::SubProcess::Group Documentation

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,6 +10,7 @@ WriteMakefile(
     # VERSION     => '2.0.2',
     MIN_PERL_VERSION => '5.010',
     test             => { TESTS => 't/*.t' },
+    EXE_FILES        => ['bin/run_subprocess.pl'],
     BUILD_REQUIRES   => {
         'ExtUtils::MakeMaker' => '6.46',
     },

--- a/lib/Process/SubProcess.pm
+++ b/lib/Process/SubProcess.pm
@@ -1,6 +1,6 @@
 #---------------------------------
 # @author Bodo (Hugo) Barwich
-# @version 2023-09-22
+# @version 2023-09-23
 # @package SubProcess Management
 # @subpackage Process/SubProcess.pm
 
@@ -44,7 +44,7 @@ use IO::Select;
 use IPC::Open3;
 use Symbol qw(gensym);
 
-our $VERSION = '2.1.6';
+our $VERSION = '2.1.7';
 
 =head1 DESCRIPTION
 
@@ -378,11 +378,15 @@ sub setCommand {
 =item setReadTimeout ( TIMEOUT )
 
 This method sets the C<READTIMEOUT> property as numeric value that represents
-the Time in seconds to wait for the process output.
+the time in seconds to wait for the command output.
 If the process is expected to run longer it is useful to set it to avoid excessive checks.
 It is also important for multiple process execusions, because other processes will not
 be checked before the read has not timed out.
 It can only be set when the Sub Process is not running.
+
+B<Parameters:>
+
+C<TIMEOUT> - is an integer that specifies how long the manager will be waiting for output.
 
 See L<Method C<Launch()>|/"Launch ()">
 

--- a/lib/Process/SubProcess/Group.pm
+++ b/lib/Process/SubProcess/Group.pm
@@ -1,6 +1,6 @@
 #---------------------------------
 # @author Bodo (Hugo) Barwich
-# @version 2023-09-22
+# @version 2023-09-23
 # @package SubProcess Management
 # @subpackage Process/SubProcess/Group.pm
 
@@ -153,6 +153,24 @@ sub DESTROY {
 
 =head1 Administration Methods
 
+=over 4
+
+=item add ( [ OBJECT | CLASS ] )
+
+This method adds a B<Process> object to the list of managed processes.
+
+B<Parameters:>
+
+C<OBJECT | CLASS> - is a C<Process::SubProcess> object or a compatible class name.
+If a class name or no parameter is given a new object will be created.
+
+B<Returns:> It returns the object that was addded to list.
+If an object was given the same will be returned.
+
+See L<Method C<Process::SubProcess::setArrProcess()>|Process::SubProcess/"setReadTimeout ( TIMEOUT )">
+
+=back
+
 =cut
 
 sub add {
@@ -257,7 +275,7 @@ sub add {
 
 =item setCheckInterval ( INTERVAL )
 
-This method calculates the C<READTIMEOUT> for each C<Process::SubProces> object according to
+This method calculates the C<READTIMEOUT> for each C<Process::SubProcess> object according to
 the amount of existing objects. The value of the C<READTIMEOUT> for each Process will be rounded
 to a whole number.
 
@@ -274,7 +292,7 @@ B<Parameters:>
 C<INTERVAL> - is an integer that specifies the interval in which each process should
 be checked.
 
-See L<Method C<Process::SubProcess::setArrProcess()>|SubProcess/"setReadTimeout ( TIMEOUT )">
+See L<Method C<Process::SubProcess::setArrProcess()>|Process::SubProcess/"setReadTimeout ( TIMEOUT )">
 
 =back
 
@@ -310,6 +328,25 @@ sub setCheckInterval {
         $self->setReadTimeout($irdtmout);
     } #if($self->{"_check_interval"} > 0 && scalar(@{$self->{"_array_processes"}}) > 0)
 }
+
+=pod
+
+=over 4
+
+=item setReadTimeout ( TIMEOUT )
+
+This method set the C<READTIMEOUT> for each C<Process::SubProcess> object.
+
+B<Parameters:>
+
+C<TIMEOUT> - is an integer that specifies the time in seconds to wait for output
+from the command.
+
+See L<Method C<Process::SubProcess::setArrProcess()>|Process::SubProcess/"setReadTimeout ( TIMEOUT )">
+
+=back
+
+=cut
 
 sub setReadTimeout {
     my $self = shift;


### PR DESCRIPTION
continuing the effort to document the modules as stated at:
[Automated Documentation](https://github.com/bodo-hugo-barwich/Process/issues/29)
this corrects inter module links and adds new methods for `Process::SubProcess::Group`

This should also install the `run_subprocess.pl` script for command line execution.