### PR TITLE
Use SubProcess start time in Group Wait() method

### DIFF
--- a/lib/Process/SubProcess.pm
+++ b/lib/Process/SubProcess.pm
@@ -1,6 +1,6 @@
 #---------------------------------
 # @author Bodo (Hugo) Barwich
-# @version 2023-09-23
+# @version 2023-10-07
 # @package SubProcess Management
 # @subpackage Process/SubProcess.pm
 
@@ -44,7 +44,7 @@ use IO::Select;
 use IPC::Open3;
 use Symbol qw(gensym);
 
-our $VERSION = '2.1.8';
+our $VERSION = '2.1.9';
 
 =head1 DESCRIPTION
 
@@ -459,6 +459,27 @@ sub setTimeout {
         $self->{'_execution_timeout'} = -1;
     }           #if(scalar(@_) > 1)
 }
+
+=pod
+
+=over 4
+
+=item setProfiling ( PROFILING )
+
+This method activated the B<Execution Time> measuring.
+
+It can only be set when the Sub Process is not running.
+
+B<Parameters:>
+
+C<PROFILING> - whole number to enable or disable the profiling. Negative numbers or C< 0 >
+will disable it. Positive numbers or C< 1 > will enable it.
+
+See L<Method C<Launch()>|/"Launch ()">
+
+=back
+
+=cut
 
 sub setProfiling {
     my $self = $_[0];
@@ -1437,6 +1458,85 @@ sub getErrorCode {
 sub getProcessStatus {
     return $_[0]->{'_process_status'};
 }
+
+=pod
+
+=over 4
+
+=item getStartTime ()
+
+This method returns the B<Start Time>. The B<Start Time> is measured at the moment
+of the launch of the Sub Process.
+
+This feature has to be enabled with the C<setProfiling()> method.
+
+It has only a value after the Sub Process is launched.
+
+B<Returns:> It returns floating point number representing the time when the Sub Process
+was launched.
+
+See L<Method C<Launch()>|/"Launch ()">
+
+See L<Method C<setProfiling()>|/"setProfiling ( PROFILING )">
+
+=back
+
+=cut
+
+sub getStartTime {
+    return $_[0]->{'_start_time'};
+}
+
+=pod
+
+=over 4
+
+=item getEndTime ()
+
+This method returns the B<End Time>. The B<End Time> is measured at the moment
+when the Sub Process is detected as terminated.
+
+This feature has to be enabled with the C<setProfiling()> method.
+
+It has only a value after the Sub Process is terminated.
+
+B<Returns:> It returns floating point number representing the time when the Sub Process
+was terminated and reaped.
+
+See L<Method C<Launch()>|/"Launch ()">
+
+See L<Method C<setProfiling()>|/"setProfiling ( PROFILING )">
+
+=back
+
+=cut
+
+sub getEndTime {
+    return $_[0]->{'_end_time'};
+}
+
+=pod
+
+=over 4
+
+=item getExecutionTime ()
+
+This method returns the B<Execution Time>. The B<Execution Time> is the micro second
+precision time span between the launch of the Sub Process until its termination.
+
+This feature has to be enabled with the C<setProfiling()> method.
+
+It has only a value after the Sub Process is terminated.
+
+B<Returns:> It returns floating point number representing the B<Execution Time>.
+
+See L<Method C<Launch()>|/"Launch ()">
+
+See L<Method C<setProfiling()>|/"setProfiling ( PROFILING )">
+
+=back
+
+=cut
 
 sub getExecutionTime {
     return $_[0]->{'_execution_time'};

--- a/lib/Process/SubProcess/Group.pm
+++ b/lib/Process/SubProcess/Group.pm
@@ -1,6 +1,6 @@
 #---------------------------------
 # @author Bodo (Hugo) Barwich
-# @version 2023-09-23
+# @version 2023-10-07
 # @package SubProcess Management
 # @subpackage Process/SubProcess/Group.pm
 
@@ -583,6 +583,17 @@ sub Check {
                 $self->{"_report"} .= "Sub Process ${sprcnm}: checking ...\n"
                   if ( $self->{"_debug"} > 0 );
 
+                if ( $self->{'_execution_timeout'} > -1 ) {
+
+                    #Synchronise with the Sub Processes
+                    $self->{'_start_time'} = $sbprc->getStartTime
+                      if ( $self->{'_start_time'} < 0 );
+
+                    $self->{'_start_time'} = $sbprc->getStartTime
+                      if ( $sbprc->getStartTime < $self->{'_start_time'} );
+
+                }
+
                 if ( $sbprc->isRunning ) {
                     if ( $sbprc->Check ) {
 
@@ -709,6 +720,13 @@ sub Wait {
             if (   $self->{"_check_interval"} > -1
                 || $self->{"_execution_timeout"} > -1 )
             {
+                if ( $self->{'_start_time'} < $itmchkstrt ) {
+
+                    # Re-synchronise with updated Start Time
+                    $itmchkstrt = $self->{'_start_time'};
+                    $itmrngstrt = $self->{'_start_time'};
+                }
+
                 $itmchkend = time;
                 $itmrngend = $itmchkend;
 

--- a/t/test_runner.t
+++ b/t/test_runner.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # @author Bodo (Hugo) Barwich
-# @version 2023-08-20
+# @version 2023-10-07
 # @package Test for the 'run_subprocess.pl' Runner Script
 # @subpackage t/test_runner.t
 
@@ -71,11 +71,14 @@ subtest 'Runner Script Usage' => sub {
   $srunnerresult = `$Config{perlpath} ${spath}${srunnerscript} -n "runner usage" -h`;
   $irunnerstatus = $?;
 
+  print("Runner Result:\n'$srunnerresult'\n");
+  print("Runner EXIT CODE: '$irunnerstatus'\n");
+
   isnt($srunnerresult, undef, "Runner Result is returned");
   ok($irunnerstatus =~ qr/^-?\d$/, "Runner EXIT CODE is numeric");
   is($irunnerstatus, 0, "Runner EXIT CODE '0' is correct");
 
-  ok(index($srunnerresult, '-h --help') != -1, "Runner Usage Message is printed");
+  ok($srunnerresult =~ qr/-h\s+--help/, "Runner Usage Message is printed");
 };
 
 subtest 'Runner Plain Text Result' => sub {


### PR DESCRIPTION
To address the issues:
* https://github.com/bodo-hugo-barwich/Process/issues/49
* https://github.com/bodo-hugo-barwich/Process/issues/48
* https://github.com/bodo-hugo-barwich/Process/issues/47
* https://github.com/bodo-hugo-barwich/Process/issues/39
* https://github.com/bodo-hugo-barwich/Process/issues/20

The `Process::SubProcess` objects will not expose the **Start Time** of the process which is then used to update the `Process::SubProcess::Group` **Start Time** so that the **Execution Time** will be more reliable in `Process::SubProcess::Group`.

Also the `test_runner.t` test will include verbose output and the parsing check will look for more flexible formatting of the help message

Additionally the new methods and more methods in `Process::SubProcess` have documentation now as the on-going effort to enhance the documentation as 
documented at:
[Automated Documentation](https://github.com/bodo-hugo-barwich/Process/issues/29)