### PR TITLE
Testing with Perl Version Matrix

### DIFF
--- a/.github/workflows/perl_versions.yml
+++ b/.github/workflows/perl_versions.yml
@@ -75,10 +75,14 @@ jobs:
           
       - name: Run the Test Suite
         run: |
-          echo "Build and Test the Module"
           eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+          echo "perlbrew - Installed Versions:"
+          perlbrew list
+          echo "perlbrew - Switch to Perl Version '${{ steps.perl_full_version.outputs.version }}' ..." 
+          perlbrew switch perl-${{ steps.perl_full_version.outputs.version }} && perl -v
           echo "Testing - Active Perl Version:"
           perl -v && perl -MConfig -e 'print "perl path: $Config{perlpath}\n"'
+          echo "Build and Test the Module"
           perl Makefile.PL
           make
           make test TEST_VERBOSE=1

--- a/.github/workflows/perl_versions.yml
+++ b/.github/workflows/perl_versions.yml
@@ -51,6 +51,9 @@ jobs:
           perlbrew list
           full_version=`perlbrew list | grep ${{ matrix.perl-version }} | sed -re 's/.*perl\-([0-9]+\.[0-9]+\.[0-9]+).*/\1/'`
           echo "version=$full_version" >> $GITHUB_OUTPUT
+        
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
 
       - name: Install requested Perl Version
         run: |

--- a/.github/workflows/perl_versions.yml
+++ b/.github/workflows/perl_versions.yml
@@ -6,9 +6,6 @@ on:
   workflow_dispatch:
      branches: [ master ]  
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
   perl-version-testing:
 
@@ -49,7 +46,7 @@ jobs:
           echo "perlbrew - Inspect Available Perl Versions"
           perlbrew available
           perlbrew list
-          full_version=`perlbrew list | grep ${{ matrix.perl-version }} | sed -re 's/.*perl\-([0-9]+\.[0-9]+\.[0-9]+).*/\1/'`
+          full_version=`perlbrew list | grep "${{ matrix.perl-version }}" | sed -re 's/.*perl-([0-9]+\.[0-9]+\.[0-9]+).*/\1/' | sed -n 1p`
           echo "version=$full_version" >> $GITHUB_OUTPUT
         
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/perl_versions.yml
+++ b/.github/workflows/perl_versions.yml
@@ -78,7 +78,7 @@ jobs:
           echo "Build and Test the Module"
           eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
           echo "Testing - Active Perl Version:"
-          perl -v 
+          perl -v && perl -MConfig -e 'print "perl path: $Config{perlpath}\n"'
           perl Makefile.PL
           make
           make test TEST_VERBOSE=1

--- a/.github/workflows/perl_versions.yml
+++ b/.github/workflows/perl_versions.yml
@@ -69,7 +69,7 @@ jobs:
           echo "perlbrew - Installed Versions:"
           perlbrew list
           echo "perlbrew - Switch to Perl Version '${{ steps.perl_full_version.outputs.version }}' ..." 
-          perlbrew switch perl-${{ steps.perl_full_version.outputs.version }} 
+          perlbrew switch perl-${{ steps.perl_full_version.outputs.version }} && perl -v
           echo "perlbrew - Active Perl Version:"
           perl -v 
           
@@ -77,6 +77,8 @@ jobs:
         run: |
           echo "Build and Test the Module"
           eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+          echo "Testing - Active Perl Version:"
+          perl -v 
           perl Makefile.PL
           make
           make test TEST_VERBOSE=1

--- a/.github/workflows/perl_versions.yml
+++ b/.github/workflows/perl_versions.yml
@@ -18,6 +18,13 @@ jobs:
         perl-version: [ "5.10", "5.16", "5.24", "5.32", "5.36", "5.38" ]
 
     steps:
+      - name: Listing Directory Contents
+        run: | 
+          echo "USER: " $(whoami) 
+          echo "HOME: '$HOME'"
+          pwd
+          ls -lah
+        
        # List all installed Perl Libraries
       - name: List all installed Perl Libraries
         run: |
@@ -53,7 +60,7 @@ jobs:
           eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
           cpanm -v --installdeps --with-feature=test_perl-versions . 
           perl-build --definitions ;
-          perl-build ${{ matrix.perl-version }} ~/perl5/perlbrew/perls/perl-${{ matrix.perl-version }} && perlbrew switch ${{ matrix.perl-version }} 
+          perl-build ${{ steps.perl_full_version.version }} ~/perl5/perlbrew/perls/perl-${{ matrix.perl-version }} && perlbrew switch ${{ steps.perl_full_version.version }} 
           perl -v 
           
       - name: Run the Test Suite

--- a/.github/workflows/perl_versions.yml
+++ b/.github/workflows/perl_versions.yml
@@ -63,7 +63,7 @@ jobs:
           eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
           cpanm -v --installdeps --with-feature=test_perl-versions . 
           perl-build --definitions ;
-          perl-build ${{ steps.perl_full_version.version }} ~/perl5/perlbrew/perls/perl-${{ matrix.perl-version }} && perlbrew switch ${{ steps.perl_full_version.version }} 
+          perl-build ${{ steps.perl_full_version.outputs.version }} ~/perl5/perlbrew/perls/perl-${{ matrix.perl-version }} && perlbrew switch ${{ steps.perl_full_version.outputs.version }} 
           perl -v 
           
       - name: Run the Test Suite

--- a/.github/workflows/perl_versions.yml
+++ b/.github/workflows/perl_versions.yml
@@ -69,7 +69,7 @@ jobs:
           echo "perlbrew - Installed Versions:"
           perlbrew list
           echo "perlbrew - Switch to Perl Version '${{ steps.perl_full_version.outputs.version }}' ..." 
-          perlbrew switch ${{ steps.perl_full_version.outputs.version }} 
+          perlbrew switch perl-${{ steps.perl_full_version.outputs.version }} 
           echo "perlbrew - Active Perl Version:"
           perl -v 
           

--- a/.github/workflows/perl_versions.yml
+++ b/.github/workflows/perl_versions.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        perl-version: [ "5.10.1", "5.16", "5.24", "5.32.1", "5.36.0", "5.38.0" ]
+        perl-version: [ "5.10", "5.16", "5.24", "5.32", "5.36", "5.38" ]
 
     steps:
        # List all installed Perl Libraries
@@ -37,14 +37,18 @@ jobs:
           sudo apt-get -y install libcpanel-json-xs-perl libjson-xs-perl libjson-perl libyaml-libyaml-perl libyaml-perl
         
       - name: Inspect Available Perl Versions
+        id: perl_full_version
         run: |
           echo "perlbrew - Inspect Available Perl Versions"
           perlbrew available
           perlbrew list
+          full_version=`perlbrew list | grep ${{ matrix.perl-version }} | sed -re 's/.*perl\-([0-9]+\.[0-9]+\.[0-9]+).*/\1/'`
+          echo "version=$full_version" >> $GITHUB_OUTPUT
 
       - name: Install requested Perl Version
         run: |
           echo "perlbrew - Install Perl Version '${{ matrix.perl-version }}'"
+          echo "perlbrew - Perl Full Version '${{ steps.perl_full_version.version }}'"
           perl -Mlocal::lib
           eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
           cpanm -v --installdeps --with-feature=test_perl-versions . 

--- a/.github/workflows/perl_versions.yml
+++ b/.github/workflows/perl_versions.yml
@@ -1,0 +1,60 @@
+name: Testing against Perl Versions
+
+on:
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+     branches: [ master ]  
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  perl-version-testing:
+
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        perl-version: [ "5.10.1", "5.16", "5.24", "5.32.1", "5.36.0", "5.38.0" ]
+
+    steps:
+       # List all installed Perl Libraries
+      - name: List all installed Perl Libraries
+        run: |
+          dpkg --get-selections | grep -i perl | sort
+          echo "Perl Version:"
+          perl --version
+        
+      # Install missing Perl Libraries
+      - name: Install Perl Libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install perlbrew cpanminus liblocal-lib-perl
+          sudo apt-get -y install libdevel-patchperl-perl libcpan-perl-releases-perl libmodule-build-perl libmodule-build-tiny-perl
+          sudo apt-get -y install libextutils-config-perl libextutils-helpers-perl libextutils-installpaths-perl
+          sudo apt-get -y install libfile-which-perl libipc-run3-perl libhttp-tiny-perl
+          sudo apt-get -y install libgetopt-long-descriptive-perl libcapture-tiny-perl libdata-dump-perl libpath-tiny-perl
+          sudo apt-get -y install libcpanel-json-xs-perl libjson-xs-perl libjson-perl libyaml-libyaml-perl libyaml-perl
+        
+      - name: Inspect Available Perl Versions
+        run: |
+          echo "perlbrew - Inspect Available Perl Versions"
+          perlbrew available
+          perlbrew list
+
+      - name: Install requested Perl Version
+        run: |
+          echo "perlbrew - Install Perl Version '${{ matrix.perl-version }}'"
+          perl -Mlocal::lib
+          eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+          cpanm -v --installdeps --with-feature=test_perl-versions . 
+          perl-build --definitions ;
+          perl-build ${{ matrix.perl-version }} ~/perl5/perlbrew/perls/perl-${{ matrix.perl-version }} && perlbrew switch ${{ matrix.perl-version }} 
+          perl -v 
+          
+      - name: Run the Test Suite
+        run: |
+          echo "Build and Test the Module"
+          perl Makefile.PL
+          make build
+          make test TEST_VERBOSE=1

--- a/.github/workflows/perl_versions.yml
+++ b/.github/workflows/perl_versions.yml
@@ -58,12 +58,15 @@ jobs:
       - name: Install requested Perl Version
         run: |
           echo "perlbrew - Install Perl Version '${{ matrix.perl-version }}'"
-          echo "perlbrew - Perl Full Version '${{ steps.perl_full_version.version }}'"
+          echo "perlbrew - Perl Full Version '${{ steps.perl_full_version.outputs.version }}'"
           perl -Mlocal::lib
           eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
           cpanm -v --installdeps --with-feature=test_perl-versions . 
           perl-build --definitions ;
-          perl-build ${{ steps.perl_full_version.outputs.version }} ~/perl5/perlbrew/perls/perl-${{ matrix.perl-version }} && perlbrew switch ${{ steps.perl_full_version.outputs.version }} 
+          perl-build ${{ steps.perl_full_version.outputs.version }} ~/perl5/perlbrew/perls/perl-${{ steps.perl_full_version.outputs.version }}
+          echo "perlbrew - Switch to Perl Version '${{ steps.perl_full_version.outputs.version }}' ..." 
+          perlbrew switch ${{ steps.perl_full_version.outputs.version }} 
+          echo "perlbrew - Active Perl Version:"
           perl -v 
           
       - name: Run the Test Suite

--- a/.github/workflows/perl_versions.yml
+++ b/.github/workflows/perl_versions.yml
@@ -44,9 +44,12 @@ jobs:
         id: perl_full_version
         run: |
           echo "perlbrew - Inspect Available Perl Versions"
+          echo "Perl - Available Versions:"
           perlbrew available
+          echo "Perl - Installed Versions:"
           perlbrew list
-          full_version=`perlbrew list | grep "${{ matrix.perl-version }}" | sed -re 's/.*perl-([0-9]+\.[0-9]+\.[0-9]+).*/\1/' | sed -n 1p`
+          full_version=`perlbrew available | grep "${{ matrix.perl-version }}" | sed -re 's/.*perl-([0-9]+\.[0-9]+\.[0-9]+).*/\1/' | sed -n 1p`
+          echo "Perl - Requested Version:" $full_version
           echo "version=$full_version" >> $GITHUB_OUTPUT
         
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -67,5 +70,5 @@ jobs:
         run: |
           echo "Build and Test the Module"
           perl Makefile.PL
-          make build
+          make
           make test TEST_VERBOSE=1

--- a/.github/workflows/perl_versions.yml
+++ b/.github/workflows/perl_versions.yml
@@ -44,6 +44,8 @@ jobs:
         id: perl_full_version
         run: |
           echo "perlbrew - Inspect Available Perl Versions"
+          echo "perlbrew - Environment:"
+          perlbrew env
           echo "Perl - Available Versions:"
           perlbrew available
           echo "Perl - Installed Versions:"
@@ -64,6 +66,8 @@ jobs:
           cpanm -v --installdeps --with-feature=test_perl-versions . 
           perl-build --definitions ;
           perl-build ${{ steps.perl_full_version.outputs.version }} ~/perl5/perlbrew/perls/perl-${{ steps.perl_full_version.outputs.version }}
+          echo "perlbrew - Installed Versions:"
+          perlbrew list
           echo "perlbrew - Switch to Perl Version '${{ steps.perl_full_version.outputs.version }}' ..." 
           perlbrew switch ${{ steps.perl_full_version.outputs.version }} 
           echo "perlbrew - Active Perl Version:"

--- a/.github/workflows/perl_versions.yml
+++ b/.github/workflows/perl_versions.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Run the Test Suite
         run: |
           echo "Build and Test the Module"
+          eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
           perl Makefile.PL
           make
           make test TEST_VERBOSE=1

--- a/.github/workflows/perl_versions.yml
+++ b/.github/workflows/perl_versions.yml
@@ -78,8 +78,8 @@ jobs:
           eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
           echo "perlbrew - Installed Versions:"
           perlbrew list
-          echo "perlbrew - Switch to Perl Version '${{ steps.perl_full_version.outputs.version }}' ..." 
-          perlbrew switch perl-${{ steps.perl_full_version.outputs.version }} && perl -v
+          echo "perlbrew - Use Perl Version '${{ steps.perl_full_version.outputs.version }}' ..." 
+          perlbrew use perl-${{ steps.perl_full_version.outputs.version }} && perl -v
           echo "Testing - Active Perl Version:"
           perl -v && perl -MConfig -e 'print "perl path: $Config{perlpath}\n"'
           echo "Build and Test the Module"

--- a/cpanfile
+++ b/cpanfile
@@ -9,7 +9,7 @@ on 'test' => sub {
   requires 'Capture::Tiny';
 };
 
-feature 'test_perl-5.10', 'testing in perl 5.10' => sub {
+feature 'test_perl-versions', 'testing in different Perl Versions' => sub {
   requires 'local::lib';
   requires 'Perl::Build';
 };

--- a/cpanfile
+++ b/cpanfile
@@ -9,7 +9,7 @@ on 'test' => sub {
   requires 'Capture::Tiny';
 };
 
-feature 'test_perl-versions', 'testing in different Perl Versions' => sub {
+feature 'test_perl-versions', 'Testing against different Perl Versions' => sub {
   requires 'local::lib';
   requires 'Perl::Build';
 };

--- a/t/test_runner.t
+++ b/t/test_runner.t
@@ -64,6 +64,7 @@ my $iprccnt = -1;
 my $iprctmoutcnt = -1;
 
 
+print "Perl Interpreter Version: '$]'\n";
 print "Perl Interpreter Path: '", $Config{perlpath}, "'\n";
 
 subtest 'Runner Script Usage' => sub {


### PR DESCRIPTION
To test the module against different _Perl_ Versions.
A testing matrix is required to define different scenarios.
As requested at:
https://github.com/bodo-hugo-barwich/Process/issues/30

closes #30 